### PR TITLE
Use restart task instead of handler for systemd-resolved

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,1 @@
 ---
-- name: Restart systemd-resolved service
-  systemd:
-    name: systemd-resolved
-    daemon_reload: yes
-    state: restarted
-  become: true

--- a/tasks/bionic.yml
+++ b/tasks/bionic.yml
@@ -35,7 +35,15 @@
   with_items:
     - src: bionic/resolved.conf.j2
       dest: /etc/systemd/resolved.conf
-  notify: Restart systemd-resolved service
+  register: resolved_conf
+
+- name: Restart systemd-resolved service
+  when: resolved_conf.changed
+  systemd:
+    name: systemd-resolved
+    daemon_reload: yes
+    state: restarted
+  become: true
 
 - name: Link /etc/resolv.conf to /run/systemd/resolve/stub-resolv.conf
   file:


### PR DESCRIPTION
The systemd-resolved service has to be restarted immediately. Otherwise
following roles will fail. The handler gets called after all roles have
been applied.