### PR TITLE
Fix deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: Include release specific tasks
   include: "{{ ansible_distribution_release }}.yml"
-  when: resolvconf_nameserver
+  when: resolvconf_nameserver|length > 0


### PR DESCRIPTION
[DEPRECATION WARNING]: evaluating 'resolvconf_nameserver' as a bare variable

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>